### PR TITLE
feat: add dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,6 +23,10 @@ h1 {
     color: var(--text-color);
 }
 
+footer a svg {
+    fill: var(--text-color);
+}
+
 /* Estilos para el formulario */
 .btn-primary {
     background-color: var(--primary-button-color);
@@ -50,4 +54,23 @@ h1 {
 
 .form-control::placeholder {
     color: #888888;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background-color: #121212;
+        --text-color: #ffffff;
+        --accent-color: #ff7722;
+        --primary-button-hover-color: #ffcc00;
+    }
+
+    .form-control {
+        background-color: #333333;
+        border-color: #555555;
+        color: var(--text-color);
+    }
+
+    .form-control::placeholder {
+        color: #aaaaaa;
+    }
 }


### PR DESCRIPTION
- Add dark mode support using a `prefers-color-scheme` media query.
- Redefine CSS variables for a dark theme.
- Ensure social media icons are visible in dark mode.